### PR TITLE
Don't iterate forever given an unknown step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Guard against ending up in an infinite loop when given an unknow step configuration in `#every`.
+
 ## [1.0.0] - 2022-10-07
 
 ### Added

--- a/lib/day_range.rb
+++ b/lib/day_range.rb
@@ -6,6 +6,13 @@ require_relative "day_range/version"
 class DayRange < Range
   class Error < StandardError; end
 
+  VALID_STEPS = [
+    :days,
+    :months,
+    :weeks,
+    :years
+  ]
+
   # Returns the number of days in the timeframe.
   def days
     last - first + 1
@@ -24,6 +31,13 @@ class DayRange < Range
   #     day_range.every(days: 1, months: 2, years: 3)
   #
   def every(step)
+    unless step.keys.all? { |k| VALID_STEPS.include?(k) }
+      raise \
+        ArgumentError,
+        "step must one or more of #{VALID_STEPS.inspect}. " \
+        "Got #{step.keys.inspect}"
+    end
+
     c_date = first
     finish_date = last
     comparison_operator = exclude_end? ? :< : :<=

--- a/test/test_day_range.rb
+++ b/test/test_day_range.rb
@@ -80,6 +80,12 @@ class TestDayRange < Minitest::Test
     assert_kind_of Array, day_range.every(days: 42)
   end
 
+  def test_raises_an_error_if_given_an_unknown_internal
+    assert_raises(ArgumentError) {
+      day_range.every(day: 1)
+    }
+  end
+
   def test_every_steps_through_days
     dates = day_range.every(days: 1)
 


### PR DESCRIPTION
This seems to be a problem with #advance, which is used by #every. It silently returns the same value if options don't contain a known step key, and that's fine for advance.

But in #every, where we iterate over the range, we end up in an infinite loop if we don't have a known step key.